### PR TITLE
Replace java.net.URL/URI with Ktor Url for KMP compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,8 +99,8 @@ subprojects {
     tasks.withType<KotlinJvmCompile> {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
-            languageVersion.set(KotlinVersion.KOTLIN_2_0)
-            apiVersion.set(KotlinVersion.KOTLIN_2_0)
+            languageVersion.set(KotlinVersion.KOTLIN_2_1)
+            apiVersion.set(KotlinVersion.KOTLIN_2_1)
             if (JavaVersion.current().isJava9Compatible && project.name != "android") {
                 freeCompilerArgs.add("-Xjdk-release=1.8")
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 android = "4.1.1.4"
 assertj = "3.27.6"
 coroutines = "1.10.2"
+ktor = "3.3.3"
 dokka = "2.1.0"
 junit = "4.13.2"
 kotlin = "2.2.21"
@@ -34,6 +35,7 @@ kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
+ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 maven-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenplugin" }
 mockito = { module = "org.mockito.kotlin:mockito-kotlin", version = "4.1.0" }
 moshiKotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     // Part of API contract
     api(libs.kotlin.coroutines.core)
     api(libs.okio.core)
+    api(libs.ktor.http)
 
     implementation(libs.moshiKotlin)
 

--- a/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
+++ b/library/src/main/kotlin/com/connectrpc/ProtocolClientConfig.kt
@@ -22,7 +22,7 @@ import com.connectrpc.protocols.GETConfiguration
 import com.connectrpc.protocols.GRPCInterceptor
 import com.connectrpc.protocols.GRPCWebInterceptor
 import com.connectrpc.protocols.NetworkProtocol
-import java.net.URI
+import io.ktor.http.Url
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -92,7 +92,7 @@ class ProtocolClientConfig @JvmOverloads constructor(
 ) {
     private val internalInterceptorFactoryList = mutableListOf<(ProtocolClientConfig) -> Interceptor>()
     private val compressionPools = mutableMapOf<String, CompressionPool>()
-    internal val baseUri: URI
+    internal val baseUrl: Url
 
     init {
         val protocolInterceptor: (ProtocolClientConfig) -> Interceptor = when (networkProtocol) {
@@ -117,7 +117,11 @@ class ProtocolClientConfig @JvmOverloads constructor(
         for (compressionPool in compressionPools) {
             this.compressionPools[compressionPool.name()] = compressionPool
         }
-        baseUri = URI(host)
+        baseUrl = Url(host)
+        val scheme = baseUrl.protocol.name
+        require(scheme == "http" || scheme == "https") {
+            "Unsupported URL scheme: $scheme (only http and https are supported)"
+        }
     }
 
     /**

--- a/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
+++ b/library/src/main/kotlin/com/connectrpc/http/HTTPRequest.kt
@@ -16,8 +16,8 @@ package com.connectrpc.http
 
 import com.connectrpc.Headers
 import com.connectrpc.MethodSpec
+import io.ktor.http.Url
 import okio.Buffer
-import java.net.URL
 import kotlin.time.Duration
 
 enum class HTTPMethod(
@@ -32,7 +32,7 @@ enum class HTTPMethod(
  */
 open class HTTPRequest internal constructor(
     // The URL for the request.
-    val url: URL,
+    val url: Url,
     // Value to assign to the `content-type` header.
     val contentType: String,
     // The optional timeout for this request.
@@ -51,7 +51,7 @@ open class HTTPRequest internal constructor(
  */
 fun HTTPRequest.clone(
     // The URL for the request.
-    url: URL = this.url,
+    url: Url = this.url,
     // Value to assign to the `content-type` header.
     contentType: String = this.contentType,
     // The optional timeout for this request.
@@ -76,7 +76,7 @@ fun HTTPRequest.clone(
  */
 class UnaryHTTPRequest(
     // The URL for the request.
-    url: URL,
+    url: Url,
     // Value to assign to the `content-type` header.
     contentType: String,
     // The optional timeout for this request.
@@ -94,7 +94,7 @@ class UnaryHTTPRequest(
 
 fun UnaryHTTPRequest.clone(
     // The URL for the request.
-    url: URL = this.url,
+    url: Url = this.url,
     // Value to assign to the `content-type` header.
     contentType: String = this.contentType,
     // The optional timeout for this request.

--- a/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/InterceptorChainTest.kt
@@ -21,13 +21,13 @@ import com.connectrpc.http.clone
 import com.connectrpc.protocols.CONTENT_TYPE
 import com.connectrpc.protocols.Envelope
 import com.connectrpc.protocols.NetworkProtocol
+import io.ktor.http.Url
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.net.URL
 
 private val UNARY_METHOD_SPEC = MethodSpec(
     path = "",
@@ -76,7 +76,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_unary() {
-        val response = unaryChain.requestFunction(UnaryHTTPRequest(URL("https://connectrpc.com"), "", null, emptyMap(), UNARY_METHOD_SPEC, Buffer()))
+        val response = unaryChain.requestFunction(UnaryHTTPRequest(Url("https://connectrpc.com"), "", null, emptyMap(), UNARY_METHOD_SPEC, Buffer()))
         assertThat(response.headers["id"]).containsExactly("1", "2", "3", "4")
     }
 
@@ -88,7 +88,7 @@ class InterceptorChainTest {
 
     @Test
     fun fifo_request_stream() {
-        val request = streamingChain.requestFunction(HTTPRequest(URL("https://connectrpc.com"), "", null, emptyMap(), STREAM_METHOD_SPEC))
+        val request = streamingChain.requestFunction(HTTPRequest(Url("https://connectrpc.com"), "", null, emptyMap(), STREAM_METHOD_SPEC))
         assertThat(request.headers["id"]).containsExactly("1", "2", "3", "4")
     }
 

--- a/library/src/test/kotlin/com/connectrpc/ProtocolClientConfigTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/ProtocolClientConfigTest.kt
@@ -15,30 +15,35 @@
 package com.connectrpc
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.fail
 import org.junit.Test
 import org.mockito.kotlin.mock
-import java.net.MalformedURLException
 
 class ProtocolClientConfigTest {
 
     @Test
-    fun hostUri() {
+    fun hostUrl() {
         val config = ProtocolClientConfig(
             host = "https://connectrpc.com",
             serializationStrategy = mock { },
         )
-        assertThat(config.baseUri.host).isEqualTo("connectrpc.com")
-        assertThat(config.baseUri.toURL()).isNotNull()
+        assertThat(config.baseUrl.host).isEqualTo("connectrpc.com")
     }
 
-    @Test(expected = MalformedURLException::class)
-    fun unsupportedSchemeErrorsWhenTranslatingToURL() {
+    @Test
+    fun hostUrlWithPathPrefix() {
         val config = ProtocolClientConfig(
+            host = "https://connectrpc.com/api/v1",
+            serializationStrategy = mock { },
+        )
+        assertThat(config.baseUrl.host).isEqualTo("connectrpc.com")
+        assertThat(config.baseUrl.encodedPath).isEqualTo("/api/v1")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun unsupportedSchemeErrors() {
+        ProtocolClientConfig(
             host = "xhtp://connectrpc.com",
             serializationStrategy = mock { },
         )
-        config.baseUri.toURL()
-        fail<Unit>("expecting URL construction to fail")
     }
 }

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCInterceptorTest.kt
@@ -29,6 +29,7 @@ import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
 import com.connectrpc.http.UnaryHTTPRequest
 import com.squareup.moshi.Moshi
+import io.ktor.http.Url
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
@@ -37,7 +38,6 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.net.URL
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -67,7 +67,7 @@ class GRPCInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = 2.5.toDuration(DurationUnit.SECONDS),
                 headers = mapOf("key" to listOf("value")),
@@ -98,7 +98,7 @@ class GRPCInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = null,
                 headers = mapOf("key" to listOf("value"), "User-Agent" to listOf("my-custom-user-agent")),
@@ -127,7 +127,7 @@ class GRPCInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = null,
                 headers = emptyMap(),
@@ -157,7 +157,7 @@ class GRPCInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = null,
                 headers = emptyMap(),
@@ -316,7 +316,7 @@ class GRPCInterceptorTest {
 
         val request = streamFunction.requestFunction(
             HTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "",
                 timeout = null,
                 headers = mapOf(
@@ -350,7 +350,7 @@ class GRPCInterceptorTest {
 
         val request = streamFunction.requestFunction(
             HTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "",
                 timeout = null,
                 headers = mapOf("User-Agent" to listOf("custom-user-agent")),
@@ -378,7 +378,7 @@ class GRPCInterceptorTest {
 
         val request = streamFunction.requestFunction(
             HTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = null,
                 headers = mapOf("key" to listOf("value")),

--- a/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
+++ b/library/src/test/kotlin/com/connectrpc/protocols/GRPCWebInterceptorTest.kt
@@ -27,6 +27,7 @@ import com.connectrpc.compression.GzipCompressionPool
 import com.connectrpc.http.HTTPRequest
 import com.connectrpc.http.HTTPResponse
 import com.connectrpc.http.UnaryHTTPRequest
+import io.ktor.http.Url
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
 import org.assertj.core.api.Assertions.assertThat
@@ -34,7 +35,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.net.URL
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -63,7 +63,7 @@ class GRPCWebInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "",
                 timeout = 2.5.toDuration(DurationUnit.SECONDS),
                 headers = mapOf("key" to listOf("value")),
@@ -95,7 +95,7 @@ class GRPCWebInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "",
                 timeout = null,
                 headers = mapOf("X-User-Agent" to listOf("custom-user-agent")),
@@ -124,7 +124,7 @@ class GRPCWebInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "",
                 timeout = null,
                 headers = emptyMap(),
@@ -154,7 +154,7 @@ class GRPCWebInterceptorTest {
 
         val request = unaryFunction.requestFunction(
             UnaryHTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "",
                 timeout = null,
                 headers = emptyMap(),
@@ -349,7 +349,7 @@ class GRPCWebInterceptorTest {
 
         val request = streamFunction.requestFunction(
             HTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = null,
                 headers = mapOf("key" to listOf("value")),
@@ -380,7 +380,7 @@ class GRPCWebInterceptorTest {
 
         val request = streamFunction.requestFunction(
             HTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = null,
                 headers = mapOf("X-User-Agent" to listOf("custom-user-agent")),
@@ -408,7 +408,7 @@ class GRPCWebInterceptorTest {
 
         val request = streamFunction.requestFunction(
             HTTPRequest(
-                url = URL(config.host),
+                url = Url(config.host),
                 contentType = "content_type",
                 timeout = null,
                 headers = mapOf("key" to listOf("value")),

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/ConnectOkHttpClient.kt
@@ -135,7 +135,7 @@ class ConnectOkHttpClient @JvmOverloads constructor(
             null
         }
         val callRequest = builder
-            .url(request.url)
+            .url(request.url.toString())
             .method(method, requestBody)
             .build()
         val newCall = unaryClient.newCall(callRequest)

--- a/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
+++ b/okhttp/src/main/kotlin/com/connectrpc/okhttp/OkHttpStream.kt
@@ -49,7 +49,7 @@ internal fun OkHttpClient.initializeStream(
 ): Stream {
     val requestBody = PipeRequestBody(duplex, request.contentType.toMediaType())
     val builder = Request.Builder()
-        .url(request.url)
+        .url(request.url.toString())
         .method(HTTPMethod.POST.string, requestBody) // streams are always POSTs
     for (entry in request.headers) {
         for (values in entry.value) {


### PR DESCRIPTION
## Summary
- Add `io.ktor:ktor-http` dependency (3.3.3)
- Replace `java.net.URL` with `io.ktor.http.Url` in HTTPRequest
- Replace `java.net.URI` with `io.ktor.http.Url` in ProtocolClientConfig
- Update ProtocolClient and ConnectInterceptor to use Ktor URLBuilder
- Add URL scheme validation (http/https only) for fail-fast behavior
- Update okhttp module to convert Ktor Url to String for OkHttp

This prepares for Kotlin Multiplatform support (Issue #140).

## Behavioral Notes
- Invalid URL schemes (e.g., `xhtp://`) now throw `IllegalArgumentException` at config creation time (fail-fast), instead of `MalformedURLException` at first RPC call

## Test plan
- [x] All 99 library tests pass
- [x] Full build succeeds
- [x] Example apps build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)